### PR TITLE
Fix "Sapce" typo

### DIFF
--- a/src/widgets/text_buffer/file.rs
+++ b/src/widgets/text_buffer/file.rs
@@ -72,7 +72,7 @@ impl Display for Indentation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Indentation::Tab(x) => write!(f, "Tab ({})", x),
-            Indentation::Space(x) => write!(f, "Sapce ({})", x),
+            Indentation::Space(x) => write!(f, "Space ({})", x),
         }
     }
 }


### PR DESCRIPTION
This fixes a small typo in the main window :)

In the bottom right, it says "Sapce" instead of "Space"